### PR TITLE
Python3.7 support added

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -181,6 +181,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 


### PR DESCRIPTION
Tested locally with Python 3.7. Travis-CI support not yet added because Travis-CI does not support 3.7 yet.