### PR TITLE
core.contactmap match and match_naive functions now match_other=True …

### DIFF
--- a/conkit/core/contactmap.py
+++ b/conkit/core/contactmap.py
@@ -738,13 +738,14 @@ class ContactMap(Entity):
             else:
                 contact.false_positive = True
 
-        if not add_false_negatives:
+        if not add_false_negatives and not match_other:
             return contact_map1
 
         for contact in contact_map2:
             if contact.id not in contact_map1_set:
                 contact.false_negative = True
-                contact_map1.add(contact)
+                if add_false_negatives:
+                    contact_map1.add(contact)
 
         return contact_map1
 
@@ -876,12 +877,12 @@ class ContactMap(Entity):
         # ================================================================
         # 3. Add false negatives
         # ================================================================
-        if add_false_negatives:
-            for contactid in contact_map2.as_list():
-                contactid = tuple(contactid)
-                if contactid not in contact_map1:
+        for contactid in contact_map2.as_list():
+            contactid = tuple(contactid)
+            if contactid not in contact_map1:
+                contact_map2[contactid].false_negative = True
+                if add_false_negatives:
                     contact = contact_map2[contactid].copy()
-                    contact.false_negative = True
                     contact_map1.add(contact)
 
         # ================================================================

--- a/conkit/core/tests/test_contactmap.py
+++ b/conkit/core/tests/test_contactmap.py
@@ -535,6 +535,7 @@ class TestContactMap(unittest.TestCase):
 
         contact_map1.match(contact_map2, match_other=True, remove_unmatched=True, inplace=True)
         self.assertEqual([TP, TP], [c.status for c in contact_map1])
+        self.assertEqual([TP, TP, FN], [c.status for c in contact_map2])
         self.assertEqual([2, 2, 3], [c.res1_altseq for c in contact_map2])
         self.assertEqual([6, 7, 5], [c.res2_altseq for c in contact_map2])
 
@@ -891,6 +892,27 @@ class TestContactMap(unittest.TestCase):
         contact_map2.set_sequence_register()
 
         contact_map1.match(contact_map2, add_false_negatives=True, inplace=True, match_other=True)
+        self.assertEqual([FN, FN, FN, FN], [c.status for c in contact_map1])
+        self.assertEqual([FN, FN, FN, FN], [c.status for c in contact_map2])
+        self.assertListEqual([[1, 5], [1, 7], [2, 7], [3, 4]], contact_map2.as_list())
+
+    def test_match_15(self):
+        contact_map1 = ContactMap("foo")
+        contact_map1.sequence = Sequence("foo", "AICDEFGH")
+        contact_map1.set_sequence_register()
+
+        contact_map2 = ContactMap("bar")
+        for i, params in enumerate([(1, 5, 1.0), (1, 7, 1.0), (2, 7, 1.0), (3, 4, 1.0)]):
+            contact = Contact(*params)
+            contact.res1_altseq = params[0]
+            contact.res2_altseq = params[1]
+            contact.status = TP
+            contact_map2.add(contact)
+        contact_map2.sequence = Sequence("bar", "AICDEFGH")
+        contact_map2.set_sequence_register()
+
+        contact_map1.match(contact_map2, inplace=True, match_other=True)
+        self.assertEqual([], [c.status for c in contact_map1])
         self.assertEqual([FN, FN, FN, FN], [c.status for c in contact_map2])
         self.assertListEqual([[1, 5], [1, 7], [2, 7], [3, 4]], contact_map2.as_list())
 
@@ -946,8 +968,46 @@ class TestContactMap(unittest.TestCase):
         contact_map2.set_sequence_register()
 
         contact_map1.match_naive(contact_map2, add_false_negatives=True, inplace=True, match_other=True)
+        self.assertEqual([FN, FN, FN, FN], [c.status for c in contact_map1])
         self.assertEqual([FN, FN, FN, FN], [c.status for c in contact_map2])
         self.assertListEqual([[1, 5], [1, 7], [2, 7], [3, 4]], contact_map2.as_list())
+
+    def test_match_naive_4(self):
+        contact_map1 = ContactMap("foo")
+        for params in [(1, 5, 1.0), (1, 6, 1.0), (2, 7, 1.0), (3, 5, 1.0), (2, 8, 1.0)]:
+            contact = Contact(*params)
+            contact_map1.add(contact)
+
+        contact_map2 = ContactMap("bar")
+        for i, params in enumerate([(1, 5, 1.0), (1, 7, 1.0), (2, 7, 1.0), (3, 4, 1.0)]):
+            contact = Contact(*params)
+            contact.res1_altseq = params[0]
+            contact.res2_altseq = params[1]
+            contact.status = TP
+            contact_map2.add(contact)
+
+        contact_map1.match_naive(contact_map2, inplace=True, match_other=True)
+        self.assertEqual([TP, FP, TP, FP, FP], [c.status for c in contact_map1])
+        self.assertEqual([TP, FN, TP, FN], [c.status for c in contact_map2])
+
+    def test_match_naive_5(self):
+        contact_map1 = ContactMap("foo")
+        contact_map1.sequence = Sequence("foo", "AICDEFGH")
+        contact_map1.set_sequence_register()
+
+        contact_map2 = ContactMap("bar")
+        for i, params in enumerate([(1, 5, 1.0), (1, 7, 1.0), (2, 7, 1.0), (3, 4, 1.0)]):
+            contact = Contact(*params)
+            contact.res1_altseq = params[0]
+            contact.res2_altseq = params[1]
+            contact.status = TP
+            contact_map2.add(contact)
+        contact_map2.sequence = Sequence("bar", "AICDEFGH")
+        contact_map2.set_sequence_register()
+
+        contact_map1.match_naive(contact_map2, inplace=True, match_other=True)
+        self.assertEqual([], [c.status for c in contact_map1])
+        self.assertEqual([FN, FN, FN, FN], [c.status for c in contact_map2])
 
     def test_remove_neighbors_1(self):
         contact_map = ContactMap("test")


### PR DESCRIPTION
In `core.contactmap` functions `match` and `match_naive` functions, now `match_other=True` ALWAYS signals FNs in `contact_map2`.